### PR TITLE
Allow non-local cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if(DEFINED CMAKE_BUILD_TYPE)
     endif()
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "./cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(OpenCL QUIET)
 IF(OPENCL_FOUND)
     add_definitions( -DINOVESA_USE_CL)


### PR DESCRIPTION
Builds which are done outside the main source directory fail due to relative path to cmake files.