### PR TITLE
Implement Aborting functionality via Ctrl+C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ execute_process(
 add_definitions("-DGIT_COMMIT=\"${GIT_COMMIT}\"")
 include_directories(./inc)
 
+# Enable Interrupts (Ctrl+C).
+add_definitions(-DINOVESA_USE_INTERRUPT)
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -876,7 +876,7 @@ int main(int argc, char** argv)
     #endif
 
     // Print the last status.
-    Display::printText(status_string(grid_t1, rotations, rotations));
+    Display::printText(status_string(grid_t1, static_cast<float>(simulationstep)/steps, rotations));
 
     #ifdef INOVESA_USE_CL
     if (OCLH::active) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -686,8 +686,10 @@ int main(int argc, char** argv)
      * main simulation loop
      * (everything inside this loop will be run a multitude of times)
      */
-    unsigned int simulationstep=0, outstepnr=0;
-    for (;simulationstep<steps*rotations;simulationstep++) {
+    unsigned int simulationstep=0;
+    unsigned int outstepnr=0;
+    unsigned int laststep=steps*rotations;
+    while (simulationstep<laststep) {
         if (wkm != nullptr) {
             // works on XProjection
             wkm->update();
@@ -792,9 +794,10 @@ int main(int argc, char** argv)
 
         #ifdef INOVESA_USE_INTERRUPT
         if(interrupt) {  // break out of main loop if sigint was triggered
-	    break;
+	    laststep = simulationstep+1;
         }
         #endif // INOVESA_USE_INTERRUPT
+        simulationstep++;
     } // end of main simulation loop
 
     #ifdef INOVESA_USE_HDF5

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -830,6 +830,7 @@ int main(int argc, char** argv)
         #ifdef INOVESA_USE_INTERRUPT
 	    // Write current Timestep to the HDF5 File if interrupt was triggered
         hdf_file->appendTime(static_cast<double>(simulationstep) /static_cast<double>(steps));
+	#endif // INOVESA_USE_INTERRUPT
 
         // for the final result, everything will be saved
         hdf_file->append(grid_t1,HDF5File::AppendType::All);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -827,10 +827,7 @@ int main(int argc, char** argv)
             }
         }
         #endif // INOVESA_USE_CL
-        #ifdef INOVESA_USE_INTERRUPT
-	    // Write current Timestep to the HDF5 File if interrupt was triggered
         hdf_file->appendTime(static_cast<double>(simulationstep) /static_cast<double>(steps));
-	#endif // INOVESA_USE_INTERRUPT
 
         // for the final result, everything will be saved
         hdf_file->append(grid_t1,HDF5File::AppendType::All);


### PR DESCRIPTION
This is done by installing a SIGINT handler
Only tested on Linux systems.

This allows to interrupt/abort Inovesa and still get valid HDF5 Result files.

It adds the overhead of checking if interrupt is true on every simulation step. This might not be the best solution.

The functionality can be toggled via Cmake by setting (or omitting) add_definitions(-DINOVESA_USE_INTERRUPT)

It does currently write the last simulation step to the result file even if this step would not normally be part of that file. It destroys therefore e.g. the equidistant time axis.