### PR TITLE
Optimized damping/diffusion code for stable branch

### DIFF
--- a/inc/IO/ProgramOptions.hpp
+++ b/inc/IO/ProgramOptions.hpp
@@ -127,6 +127,12 @@ public:
     inline auto getRenormalizeCharge() const
         { return renormalize; }
 
+    inline auto getFPTrack() const
+        { return fptrack; }
+
+    inline auto getFPType() const
+        { return fptype; }
+
     inline auto getRotationType() const
         { return rotationtype; }
 
@@ -240,6 +246,8 @@ private: // simulation parameters
     uint32_t steps;
     int32_t renormalize;
     double rotations;
+    uint32_t fptype;
+    uint32_t fptrack;
     uint32_t rotationtype;
     uint32_t deriv_type;
     uint32_t interpol_type;

--- a/inc/PS/PhaseSpace.hpp
+++ b/inc/PS/PhaseSpace.hpp
@@ -189,9 +189,27 @@ public:
     inline meshaxis_t size(const uint_fast8_t x) const
     { return _axis[x]->size(); }
 
-    inline meshaxis_t x(const uint_fast8_t axis, const size_t n) const
+    /**
+     * @brief q normalized position coordinate of grid point x
+     * @param x
+     * @return
+     */
+    inline meshaxis_t q(const meshindex_t x) const
+        { return _qp(0,x); }
+
+    /**
+     * @brief p normalized energy coordinate of grid point y
+     * @param y
+     * @return
+     */
+    inline meshaxis_t p(const meshindex_t y) const
+        { return _qp(1,y); }
+
+private:
+    inline meshaxis_t _qp(const uint_fast8_t axis, const meshindex_t n) const
         { return _axis[axis]->at(n); }
 
+public:
     /**
      * @brief swap
      * @param other

--- a/inc/SM/FokkerPlanckMap.hpp
+++ b/inc/SM/FokkerPlanckMap.hpp
@@ -23,6 +23,8 @@
 
 #include "SM/SourceMap.hpp"
 
+#include <random>
+
 namespace vfps
 {
 
@@ -46,6 +48,13 @@ public:
         full=3
     };
 
+    enum class FPTracking : uint_fast8_t {
+        none=0,
+        approximation1=1,
+        approximation2=2,
+        stochastic=3
+    };
+
     enum DerivationType : uint_fast8_t {
         two_sided = 3,    // based on quadratic interpolation
         cubic = 4        // based on cubic interpolation
@@ -62,7 +71,8 @@ public:
     FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
                     std::shared_ptr<PhaseSpace> out,
                     const meshindex_t xsize, const meshindex_t ysize,
-                    FPType fpt, timeaxis_t e1, DerivationType dt);
+                    FPType fptype, FPTracking fptrack,
+                    timeaxis_t e1, DerivationType dt);
 
     ~FokkerPlanckMap() noexcept;
 
@@ -75,6 +85,19 @@ public:
     PhaseSpace::Position apply(PhaseSpace::Position pos) const override;
 
 private:
+    /**
+     * @brief _dampincr damping decrement
+     */
+    timeaxis_t _dampdecr;
+
+    mutable std::mt19937 _prng;
+
+    mutable std::normal_distribution<meshaxis_t> _normdist ;
+
+    const FPTracking _fptrack;
+
+    const FPType _fptype;
+
     /**
      * @brief _meshxsize horizontal size of the meshaxis_t
      *

--- a/src/IO/ProgramOptions.cpp
+++ b/src/IO/ProgramOptions.cpp
@@ -175,6 +175,18 @@ vfps::ProgramOptions::ProgramOptions() :
             ">0: renormalize charge every n-th simulation step\n"
             " 0: do just one initial renormalization\n"
             "<0: no renormalization")
+        ("FPType", po::value<uint32_t>(&fptype)->default_value(3),
+            "Used implementation for Fokker-Planck term\n"
+            " 0: No Fokker-Planck term\n"
+            " 1: Only damping\n"
+            " 2: Only diffusion\n"
+            " 3: Full")
+        ("FPTrack", po::value<uint32_t>(&fptrack)->default_value(3),
+            "Used implementation for FP term in tracking\n"
+            " 0: No Fokker-Planck term\n"
+            " 1: Approximation overweighting damping\n"
+            " 2: Approximation overweighting diffusion\n"
+            " 3: Stochastic")
         ("RotationType", po::value<uint32_t>(&rotationtype)->default_value(2),
             "Used implementation for rotation\n"
             " 0: Standard rotation without source map\n"

--- a/src/IO/ProgramOptions.cpp
+++ b/src/IO/ProgramOptions.cpp
@@ -181,7 +181,7 @@ vfps::ProgramOptions::ProgramOptions() :
             " 1: Only damping\n"
             " 2: Only diffusion\n"
             " 3: Full")
-        ("FPTrack", po::value<uint32_t>(&fptrack)->default_value(3),
+        ("FPTrack", po::value<uint32_t>(&fptrack)->default_value(1),
             "Used implementation for FP term in tracking\n"
             " 0: No Fokker-Planck term\n"
             " 1: Approximation overweighting damping\n"

--- a/src/PS/PhaseSpace.cpp
+++ b/src/PS/PhaseSpace.cpp
@@ -254,7 +254,7 @@ vfps::meshaxis_t vfps::PhaseSpace::average(const uint_fast8_t axis)
     }
     integral_t avg = 0;
     for (size_t i=0; i<nMeshCells(axis); i++) {
-        avg += _projection[axis][i]*x(axis,i);
+        avg += _projection[axis][i]*_qp(axis,i);
     }
 
     // _projection is normalized in p/q coordinates
@@ -270,7 +270,7 @@ vfps::meshdata_t vfps::PhaseSpace::variance(const uint_fast8_t axis)
     meshdata_t avg = average(axis);
     meshdata_t var = 0;
     for (size_t i=0; i<nMeshCells(axis); i++) {
-        var += _projection[axis][i]*std::pow(x(axis,i)-avg,2);
+        var += _projection[axis][i]*std::pow(_qp(axis,i)-avg,2);
     }
 
     // _projection is normalized in p/q coordinates

--- a/src/SM/FokkerPlanckMap.cpp
+++ b/src/SM/FokkerPlanckMap.cpp
@@ -214,17 +214,26 @@ void vfps::FokkerPlanckMap::apply()
 vfps::PhaseSpace::Position
 vfps::FokkerPlanckMap::apply(PhaseSpace::Position pos) const
 {
-    meshindex_t yi = std::min(static_cast<meshindex_t>(std::floor(pos.y)),_ysize);
+    meshdata_t* data_in = _in->getData();
+
+    std::make_signed<meshindex_t>::type xi
+            = std::min( static_cast<decltype(_in->nMeshCells(0))>(std::floor(pos.x))
+                      , _in->nMeshCells(0)-1);
+    std::make_signed<meshindex_t>::type yi
+            = std::min( static_cast<decltype(_ysize)>(std::floor(pos.y))
+                      , _ysize-1);
+    const meshindex_t offs = xi*_ysize;
     interpol_t offset = 0;
+    meshdata_t charge = 0;
 
     for (uint_fast8_t j=0; j<_ip; j++) {
         hi h = _hinfo[yi*_ip+j];
-        interpol_t dy = static_cast<interpol_t>(yi)
-                      - static_cast<interpol_t>(h.index);
-        offset += dy*h.weight;
+        charge += data_in[offs+h.index]*h.weight;
+        offset += (static_cast<std::make_signed<meshindex_t>::type>(h.index) - yi)*data_in[offs+h.index]*h.weight;
     }
+    offset /= charge;
     pos.y = std::max(static_cast<meshaxis_t>(1),
-                     std::min(pos.y+offset,static_cast<meshaxis_t>(_ysize-1)));
+                     std::min(pos.y+offset,static_cast<meshaxis_t>(_ysize-2)));
     return pos;
 }
 

--- a/src/SM/FokkerPlanckMap.cpp
+++ b/src/SM/FokkerPlanckMap.cpp
@@ -229,7 +229,7 @@ vfps::FokkerPlanckMap::apply(PhaseSpace::Position pos) const
     for (uint_fast8_t j=0; j<_ip; j++) {
         hi h = _hinfo[yi*_ip+j];
         charge += data_in[offs+h.index]*h.weight;
-        offset += (static_cast<std::make_signed<meshindex_t>::type>(h.index) - yi)*data_in[offs+h.index]*h.weight;
+        offset += (yi - static_cast<std::make_signed<meshindex_t>::type>(h.index)) * data_in[offs+h.index]*h.weight;
     }
     offset /= charge;
     pos.y = std::max(static_cast<meshaxis_t>(1),

--- a/src/SM/FokkerPlanckMap.cpp
+++ b/src/SM/FokkerPlanckMap.cpp
@@ -29,7 +29,9 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
   : SourceMap(in, out, 1, ysize, dt, dt)
   , _dampdecr(e1)
   , _prng(std::mt19937(std::random_device{}()))
-  , _normdist(std::normal_distribution<meshaxis_t>(0, std::sqrt(2*e1)))
+  , _normdist( std::normal_distribution<meshaxis_t>( 0
+                                                   , std::sqrt(2*e1)
+                                                     / in->getDelta(1)))
   , _fptrack(fptrack)
   , _fptype(fptype)
   , _meshxsize(xsize)
@@ -52,7 +54,7 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
             _hinfo[j*_ip+2]={j+1,0};
 
             if (_fptype != FPType::none && _fptype != FPType::diffusion_only) {
-                const meshaxis_t pos = in->x(1,j);
+                const meshaxis_t pos = in->p(j);
                 _hinfo[j*_ip  ].weight += -e1_2d*pos;
                 _hinfo[j*_ip+1].weight +=  e1;
                 _hinfo[j*_ip+2].weight +=  e1_2d*pos;
@@ -77,7 +79,7 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
         _hinfo[_ip+2] = {0,0};
         _hinfo[_ip+3] = {0,0};
         for (meshindex_t j=2; j< ycenter; j++) {
-            const meshaxis_t pos = in->x(1,j);
+            const meshaxis_t pos = in->p(j);
             _hinfo[j*_ip  ]={j-2,0};
             _hinfo[j*_ip+1]={j-1,0};
             _hinfo[j*_ip+2]={j  ,1};
@@ -95,7 +97,7 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
             }
         }
         for (meshindex_t j=ycenter; j<static_cast<meshindex_t>(_ysize-2);j++) {
-            const meshaxis_t pos = in->x(1,j);
+            const meshaxis_t pos = in->p(j);
             _hinfo[j*_ip  ]={j-1,0};
             _hinfo[j*_ip+1]={j  ,1};
             _hinfo[j*_ip+2]={j+1,0};

--- a/src/SM/FokkerPlanckMap.cpp
+++ b/src/SM/FokkerPlanckMap.cpp
@@ -24,11 +24,15 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
                                        std::shared_ptr<PhaseSpace> out,
                                        const meshindex_t xsize,
                                        const meshindex_t ysize,
-                                       FPType fpt, timeaxis_t e1,
-                                       DerivationType dt)
-    :
-    SourceMap(in, out, 1, ysize, dt, dt),
-    _meshxsize(xsize)
+                                       FPType fptype, FPTracking fptrack,
+                                       timeaxis_t e1, DerivationType dt)
+  : SourceMap(in, out, 1, ysize, dt, dt)
+  , _dampdecr(e1)
+  , _prng(std::mt19937(std::random_device{}()))
+  , _normdist(std::normal_distribution<meshaxis_t>(0, std::sqrt(2*e1)))
+  , _fptrack(fptrack)
+  , _fptype(fptype)
+  , _meshxsize(xsize)
 {
     // the following doubles should be interpol_t
     const interpol_t e1_2d = e1/(interpol_t(2)*in->getDelta(1));
@@ -47,16 +51,16 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
             _hinfo[j*_ip+1]={j  ,1};
             _hinfo[j*_ip+2]={j+1,0};
 
-            if (fpt == FPType::full || fpt == FPType::damping_only) {
+            if (_fptype != FPType::none && _fptype != FPType::diffusion_only) {
                 const meshaxis_t pos = in->x(1,j);
                 _hinfo[j*_ip  ].weight += -e1_2d*pos;
                 _hinfo[j*_ip+1].weight +=  e1;
                 _hinfo[j*_ip+2].weight +=  e1_2d*pos;
             }
-            if (fpt == FPType::full || fpt == FPType::diffusion_only) {
-                _hinfo[j*_ip  ].weight +=                 e1_d2;
+            if (_fptype != FPType::none && _fptype != FPType::damping_only) {
+                _hinfo[j*_ip  ].weight +=                e1_d2;
                 _hinfo[j*_ip+1].weight += interpol_t(-2)*e1_d2;
-                _hinfo[j*_ip+2].weight +=                 e1_d2;
+                _hinfo[j*_ip+2].weight +=                e1_d2;
             }
         }
         _hinfo[(_ysize-1)*_ip+0] = {0,0};
@@ -78,13 +82,13 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
             _hinfo[j*_ip+1]={j-1,0};
             _hinfo[j*_ip+2]={j  ,1};
             _hinfo[j*_ip+3]={j+1,0};
-            if (fpt == FPType::full || fpt == FPType::damping_only) {
+            if (_fptype != FPType::none && _fptype != FPType::diffusion_only) {
                 _hinfo[j*_ip  ].weight +=    e1_6d*interpol_t( 1)*pos;
                 _hinfo[j*_ip+1].weight +=    e1_6d*interpol_t(-6)*pos;
                 _hinfo[j*_ip+2].weight += e1+e1_6d*interpol_t( 3)*pos;
                 _hinfo[j*_ip+3].weight +=    e1_6d*interpol_t( 2)*pos;
             }
-            if (fpt == FPType::full || fpt == FPType::diffusion_only) {
+            if (_fptype != FPType::none && _fptype != FPType::damping_only) {
                 _hinfo[j*_ip+1].weight +=    e1_d2;
                 _hinfo[j*_ip+2].weight += interpol_t(-2)*e1_d2;
                 _hinfo[j*_ip+3].weight +=    e1_d2;
@@ -97,16 +101,16 @@ vfps::FokkerPlanckMap::FokkerPlanckMap(std::shared_ptr<PhaseSpace> in,
             _hinfo[j*_ip+2]={j+1,0};
             _hinfo[j*_ip+3]={j+2,0};
 
-            if (fpt == FPType::full || fpt == FPType::damping_only) {
+            if (_fptype != FPType::none && _fptype != FPType::diffusion_only) {
                 _hinfo[j*_ip  ].weight +=    e1_6d*interpol_t(-2)*pos;
                 _hinfo[j*_ip+1].weight += e1+e1_6d*interpol_t(-3)*pos;
                 _hinfo[j*_ip+2].weight +=    e1_6d*interpol_t( 6)*pos;
                 _hinfo[j*_ip+3].weight +=    e1_6d*interpol_t(-1)*pos;
             }
-            if (fpt == FPType::full || fpt == FPType::diffusion_only) {
-                _hinfo[j*_ip  ].weight +=                 e1_d2;
+            if (_fptype != FPType::none && _fptype != FPType::damping_only) {
+                _hinfo[j*_ip  ].weight +=                e1_d2;
                 _hinfo[j*_ip+1].weight += interpol_t(-2)*e1_d2;
-                _hinfo[j*_ip+2].weight +=                 e1_d2;
+                _hinfo[j*_ip+2].weight +=                e1_d2;
             }
         }
         _hinfo[(_ysize-2)*_ip  ] = {0,0};
@@ -214,26 +218,48 @@ void vfps::FokkerPlanckMap::apply()
 vfps::PhaseSpace::Position
 vfps::FokkerPlanckMap::apply(PhaseSpace::Position pos) const
 {
-    meshdata_t* data_in = _in->getData();
+    switch (_fptrack){
+    case FPTracking::none:
+    default:
+        break;
+    case FPTracking::approximation1:
+        {
+        meshindex_t yi = std::min( static_cast<meshindex_t>(std::floor(pos.y))
+                                 , _ysize);
+        interpol_t offset = 0;
 
-    std::make_signed<meshindex_t>::type xi
-            = std::min( static_cast<decltype(_in->nMeshCells(0))>(std::floor(pos.x))
-                      , _in->nMeshCells(0)-1);
-    std::make_signed<meshindex_t>::type yi
-            = std::min( static_cast<decltype(_ysize)>(std::floor(pos.y))
-                      , _ysize-1);
-    const meshindex_t offs = xi*_ysize;
-    interpol_t offset = 0;
-    meshdata_t charge = 0;
+        for (uint_fast8_t j=0; j<_ip; j++) {
+            hi h = _hinfo[yi*_ip+j];
+            interpol_t dy = static_cast<interpol_t>(yi)
+                          - static_cast<interpol_t>(h.index);
+            offset += dy*h.weight;
+        }
+        pos.y = std::max(static_cast<meshaxis_t>(1),
+        std::min(pos.y+offset,static_cast<meshaxis_t>(_ysize-1)));
+        }
+        break;
+    case FPTracking::approximation2:
+        {
+        meshindex_t yi = std::min( static_cast<meshindex_t>(std::floor(pos.y))
+                                 , _ysize);
+        interpol_t offset = 0;
 
-    for (uint_fast8_t j=0; j<_ip; j++) {
-        hi h = _hinfo[yi*_ip+j];
-        charge += data_in[offs+h.index]*h.weight;
-        offset += (yi - static_cast<std::make_signed<meshindex_t>::type>(h.index)) * data_in[offs+h.index]*h.weight;
+        for (uint_fast8_t j=0; j<_ip; j++) {
+            hi h = _hinfo[yi*_ip+j];
+            interpol_t dy = static_cast<interpol_t>(yi)
+                          - static_cast<interpol_t>(h.index);
+            offset += dy*h.weight;
+        }
+        pos.y = std::max( static_cast<meshaxis_t>(1)
+                        , std::min(pos.y+offset
+                                  , static_cast<meshaxis_t>(_ysize-1)));
+        }
+        break;
+    case FPTracking::stochastic:
+        auto delta = pos.y*_dampdecr+_normdist(_prng);
+        pos.y -= delta;
+        break;
     }
-    offset /= charge;
-    pos.y = std::max(static_cast<meshaxis_t>(1),
-                     std::min(pos.y+offset,static_cast<meshaxis_t>(_ysize-2)));
     return pos;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,6 +146,12 @@ int main(int argc, char** argv)
     const auto derivationtype = static_cast<FokkerPlanckMap::DerivationType>
             (opts.getDerivationType());
 
+    const auto fptype = static_cast<FokkerPlanckMap::FPType>
+            (opts.getFPType());
+
+    const auto fptrack = static_cast<FokkerPlanckMap::FPTracking>
+            (opts.getFPTrack());
+
     const auto interpolationtype = static_cast<SourceMap::InterpolationType>
             (opts.getInterpolationPoints());
 
@@ -523,10 +529,9 @@ int main(int argc, char** argv)
     // SourceMap for damping and diffusion
     SourceMap* fpm;
     if (e1 > 0) {
-        Display::printText("Building FokkerPlanckMap.");
+        Display::printText("Building FokkerPlanckMap");
         fpm = new FokkerPlanckMap( grid_t3,grid_t1,ps_size,ps_size,
-                                   FokkerPlanckMap::FPType::full,e1,
-                                   derivationtype);
+                                   fptype,fptrack,e1,derivationtype);
     } else {
         fpm = new Identity(grid_t3,grid_t1,ps_size,ps_size);
     }


### PR DESCRIPTION
As the optimized damping/diffusion code also fixes #53, I suggest to pull it into v1.0. By default there will be no visible change, as particle I/O is still in x/y coordinates and the default approximation for the Fokker-Planck term is set to the one that effectively neglects diffusion.