### PR TITLE
Include Coveralls and DOI badges to README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - cmake-data
       - cmake
       - clang-3.8
+      - cppcheck
       - g++-5
       - gcc-5
       # actual dependencies
@@ -37,11 +38,21 @@ addons:
 #  - clang
 #  - gcc
 
+before_install:
+    - pip install --user cpp-coveralls
+
 script: # set correct compiler versions first
+    - cppcheck --quiet --error-exitcode=1 .
     - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
     - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8" CC="clang-3.8"; fi
-    - cmake . -DCMAKE_BUILD_TYPE=Release
+    - cmake -DCMAKE_BUILD_TYPE=Release -DCOVERAGE=1 .
     - cmake --build .
     - ./inovesa --version
     - ./inovesa -T 0.1 -o test.h5
+    - ./inovesa -T 0.1 -i test.h5 --CollimatorRadius 0.002 --WallConductivity 3.77e7 --WallSusceptibility 2.1e-5 -o test2.png
+
+
+after_success:
+    - coveralls --root . -E ".*CMakeFiles.*"
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set (INOVESA_VERSION_FIX 2)
 # -3 RC1
 # -n RC(n-2)
 
+SET (COVERAGE OFF CACHE BOOL "Coverage")
+
 configure_file (
   "${PROJECT_SOURCE_DIR}/InovesaConfig.hpp.in"
   "${PROJECT_BINARY_DIR}/InovesaConfig.hpp"
@@ -206,7 +208,12 @@ ELSE()
 ENDIF()
 
 
-target_link_libraries(${PROJECT_NAME} ${LIBS})
+IF(COVERAGE)
+    target_compile_options(${PROJECT_NAME} PRIVATE --coverage)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS} --coverage)
+ELSE()
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS})
+ENDIF()
 
 
 INSTALL(TARGETS inovesa RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The [contibuting file](CONTRIBUTING.md) is a good starting point.
 
 ### Status
 
+
+
+[![DOI](https://zenodo.org/badge/73905339.svg)](https://zenodo.org/badge/latestdoi/73905339)
 [![Inovesa build status (branch: Master)](https://travis-ci.org/Inovesa/Inovesa.svg?branch=master)](https://travis-ci.org/Inovesa/Inovesa/branches)
 [![Coverage Status](https://coveralls.io/repos/github/Inovesa/Inovesa/badge.svg?branch=master)](https://coveralls.io/github/Inovesa/Inovesa?branch=master)
 


### PR DESCRIPTION
As it helps to have these badges, I decided to backport coveralls
integration. In this step, I also included a DOI badge pointing to zenodo.

See also: #65