### PR TITLE
Fix conversion attributes

### DIFF
--- a/inc/PS/ElectricField.hpp
+++ b/inc/PS/ElectricField.hpp
@@ -260,12 +260,12 @@ public:
     /**
      * @brief OhmsPerHertz includes factor 2 to use positive frequencies only
      */
-    const csrpower_t factor4WattPerHertz;
+    const double factor4WattPerHertz;
 
     /**
      * @brief factor4Watts includes factor 2 to use positive frequencies only
      */
-    const csrpower_t factor4Watts;
+    const double factor4Watts;
 
 private:
 

--- a/src/IO/HDF5File.cpp
+++ b/src/IO/HDF5File.cpp
@@ -162,10 +162,10 @@ vfps::HDF5File::HDF5File(const std::string filename,
     _timeAxis.dataset.createAttribute("Turn",H5::PredType::IEEE_F64LE,
                 H5::DataSpace()).write(H5::PredType::IEEE_F64LE,&axis_t_turns);
 
-    _bunchPopulation.dataset.createAttribute("Ampere",_bunchPopulation.datatype,
-            H5::DataSpace()).write(_bunchPopulation.datatype,&(ps->current));
-    _bunchPopulation.dataset.createAttribute("Coulomb",_bunchPopulation.datatype,
-            H5::DataSpace()).write(_bunchPopulation.datatype,&(ps->charge));
+    _bunchPopulation.dataset.createAttribute("Ampere",H5::PredType::IEEE_F64LE,
+            H5::DataSpace()).write(H5::PredType::IEEE_F64LE,&(ps->current));
+    _bunchPopulation.dataset.createAttribute("Coulomb",H5::PredType::IEEE_F64LE,
+            H5::DataSpace()).write(H5::PredType::IEEE_F64LE,&(ps->charge));
 
     // actual data
     _file.link(H5L_TYPE_SOFT, "/Info/AxisValues_t", "/BunchProfile/axis0" );

--- a/src/IO/HDF5File.cpp
+++ b/src/IO/HDF5File.cpp
@@ -232,7 +232,7 @@ vfps::HDF5File::HDF5File(const std::string filename,
         _file.link(H5L_TYPE_SOFT, "/Info/AxisValues_t", "/CSR/Spectrum/axis0" );
         _file.link(H5L_TYPE_SOFT, "/Info/AxisValues_f", "/CSR/Spectrum/axis1" );
 
-        _csrIntensity.dataset.createAttribute("WattPerHertz",H5::PredType::IEEE_F64LE,
+        _csrSpectrum.dataset.createAttribute("WattPerHertz",H5::PredType::IEEE_F64LE,
                 H5::DataSpace()).write(H5::PredType::IEEE_F64LE,
                                        &ef->factor4WattPerHertz);
 


### PR DESCRIPTION
- Fixes BunchPopulation attributes by using correct datatype
- Fixes CSR attributes Watt and WattPerHertz, by changing datatype of variable and moving WattPerHertz to Spectrum/data