### PR TITLE
Fix widening compare in loops

### DIFF
--- a/src/SM/FokkerPlanckMap.cpp
+++ b/src/SM/FokkerPlanckMap.cpp
@@ -4,6 +4,8 @@
  * Copyright (c) Karlsruhe Institute of Technology
  */
 
+#include <type_traits>
+
 #include "SM/FokkerPlanckMap.hpp"
 
 vfps::FokkerPlanckMap::FokkerPlanckMap( std::shared_ptr<PhaseSpace> in
@@ -198,7 +200,7 @@ void vfps::FokkerPlanckMap::apply()
                 const meshindex_t offs = offs1+x*_ysize;
                 for (meshindex_t y=0; y< _ysize; y++) {
                     meshdata_t value = 0;
-                    for (decltype(_ip) j=0; j<_ip; j++) {
+                    for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
                         hi h = _hinfo[y*_ip+j];
                         value += data_in[offs+h.index]
                                          *  static_cast<meshdata_t>(h.weight);
@@ -221,7 +223,7 @@ void vfps::FokkerPlanckMap::applyTo(PhaseSpace::Position &pos) const
                                  , _ysize);
         interpol_t offset = 0;
 
-        for (decltype(_ip) j=0; j<_ip; j++) {
+        for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
             hi h = _hinfo[yi*_ip+j];
             interpol_t dy = static_cast<interpol_t>(yi)
                           - static_cast<interpol_t>(h.index);
@@ -246,7 +248,7 @@ void vfps::FokkerPlanckMap::applyTo(PhaseSpace::Position &pos) const
         interpol_t offset = 0;
         meshdata_t charge = 0;
 
-        for (decltype(_ip) j=0; j<_ip; j++) {
+        for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
             hi h = _hinfo[yi*_ip+j];
             charge += data_in[offs+h.index]*h.weight;
             offset += data_in[offs+h.index]*h.weight

--- a/src/SM/FokkerPlanckMap.cpp
+++ b/src/SM/FokkerPlanckMap.cpp
@@ -198,7 +198,7 @@ void vfps::FokkerPlanckMap::apply()
                 const meshindex_t offs = offs1+x*_ysize;
                 for (meshindex_t y=0; y< _ysize; y++) {
                     meshdata_t value = 0;
-                    for (uint_fast8_t j=0; j<_ip; j++) {
+                    for (decltype(_ip) j=0; j<_ip; j++) {
                         hi h = _hinfo[y*_ip+j];
                         value += data_in[offs+h.index]
                                          *  static_cast<meshdata_t>(h.weight);
@@ -221,7 +221,7 @@ void vfps::FokkerPlanckMap::applyTo(PhaseSpace::Position &pos) const
                                  , _ysize);
         interpol_t offset = 0;
 
-        for (uint_fast8_t j=0; j<_ip; j++) {
+        for (decltype(_ip) j=0; j<_ip; j++) {
             hi h = _hinfo[yi*_ip+j];
             interpol_t dy = static_cast<interpol_t>(yi)
                           - static_cast<interpol_t>(h.index);
@@ -246,7 +246,7 @@ void vfps::FokkerPlanckMap::applyTo(PhaseSpace::Position &pos) const
         interpol_t offset = 0;
         meshdata_t charge = 0;
 
-        for (uint_fast8_t j=0; j<_ip; j++) {
+        for (decltype(_ip) j=0; j<_ip; j++) {
             hi h = _hinfo[yi*_ip+j];
             charge += data_in[offs+h.index]*h.weight;
             offset += data_in[offs+h.index]*h.weight

--- a/src/SM/KickMap.cpp
+++ b/src/SM/KickMap.cpp
@@ -222,7 +222,7 @@ void vfps::KickMap::apply()
             for (meshindex_t x=0; x< static_cast<meshindex_t>(_meshsize_kd); x++) {
                 for (meshindex_t y=0; y< static_cast<meshindex_t>(_meshsize_pd); y++) {
                     meshdata_t value = 0;
-                    for (uint_fast8_t j=0; j<_ip; j++) {
+                    for (decltype(_ip) j=0; j<_ip; j++) {
                         hi h = _hinfo[y*_ip+j];
                         // the min makes sure not to have out of bounds accesses
                         // casting is to be sure about overflow behaviour
@@ -246,7 +246,7 @@ void vfps::KickMap::apply()
                 const meshindex_t offs = offs1 + x*_meshsize_kd;
                 for (meshindex_t y=0; y< static_cast<meshindex_t>(_meshsize_kd); y++) {
                     meshdata_t value = 0;
-                    for (uint_fast8_t j=0; j<_ip; j++) {
+                    for (decltype(_ip) j=0; j<_ip; j++) {
                         hi h = _hinfo[offs2+x*_ip+j];
                         // the min makes sure not to have out of bounds accesses
                         // casting is to be sure about overflow behaviour

--- a/src/SM/KickMap.cpp
+++ b/src/SM/KickMap.cpp
@@ -4,6 +4,8 @@
  * Copyright (c) Karlsruhe Institute of Technology
  */
 
+#include <type_traits>
+
 #include "SM/KickMap.hpp"
 
 
@@ -222,7 +224,7 @@ void vfps::KickMap::apply()
             for (meshindex_t x=0; x< static_cast<meshindex_t>(_meshsize_kd); x++) {
                 for (meshindex_t y=0; y< static_cast<meshindex_t>(_meshsize_pd); y++) {
                     meshdata_t value = 0;
-                    for (decltype(_ip) j=0; j<_ip; j++) {
+                    for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
                         hi h = _hinfo[y*_ip+j];
                         // the min makes sure not to have out of bounds accesses
                         // casting is to be sure about overflow behaviour
@@ -246,7 +248,7 @@ void vfps::KickMap::apply()
                 const meshindex_t offs = offs1 + x*_meshsize_kd;
                 for (meshindex_t y=0; y< static_cast<meshindex_t>(_meshsize_kd); y++) {
                     meshdata_t value = 0;
-                    for (decltype(_ip) j=0; j<_ip; j++) {
+                    for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
                         hi h = _hinfo[offs2+x*_ip+j];
                         // the min makes sure not to have out of bounds accesses
                         // casting is to be sure about overflow behaviour

--- a/src/SM/RotationMap.cpp
+++ b/src/SM/RotationMap.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdexcept>
+#include <type_traits>
 
 #include "SM/RotationMap.hpp"
 
@@ -140,7 +141,7 @@ void vfps::RotationMap::apply()
                     meshindex_t i = q_i*_ysize+p_i;
                     data_out[i] = 0;
                     genHInfo(q_i,p_i,&(_hinfo[0]));
-                    for (decltype(_ip) j=0; j<_ip; j++) {
+                    for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
                         hi h = _hinfo[j];
                         data_out[i] += data_in[h.index]
                                     * static_cast<meshdata_t>(h.weight);
@@ -150,7 +151,7 @@ void vfps::RotationMap::apply()
         } else {
             for (meshindex_t i=0; i< _rotmapsize; i++) {
                 data_out[i] = 0;
-                for (decltype(_ip) j=0; j<_ip; j++) {
+                for (std::remove_const<decltype(_ip)>::type j=0; j<_ip; j++) {
                     hi h = _hinfo[i*_ip+j];
                     data_out[i] += data_in[h.index]
                                 * static_cast<meshdata_t>(h.weight);
@@ -252,7 +253,7 @@ void vfps::RotationMap::genHInfo(vfps::meshindex_t x0,
             }
         }
     } else {
-        for (decltype(_ip) i=0; i<_ip; i++) {
+        for (std::remove_const<decltype(_ip)>::type i=0; i<_ip; i++) {
             myhinfo[i] = {0,0};
         }
     }

--- a/src/SM/RotationMap.cpp
+++ b/src/SM/RotationMap.cpp
@@ -140,7 +140,7 @@ void vfps::RotationMap::apply()
                     meshindex_t i = q_i*_ysize+p_i;
                     data_out[i] = 0;
                     genHInfo(q_i,p_i,&(_hinfo[0]));
-                    for (uint_fast8_t j=0; j<_ip; j++) {
+                    for (decltype(_ip) j=0; j<_ip; j++) {
                         hi h = _hinfo[j];
                         data_out[i] += data_in[h.index]
                                     * static_cast<meshdata_t>(h.weight);
@@ -150,7 +150,7 @@ void vfps::RotationMap::apply()
         } else {
             for (meshindex_t i=0; i< _rotmapsize; i++) {
                 data_out[i] = 0;
-                for (uint_fast8_t j=0; j<_ip; j++) {
+                for (decltype(_ip) j=0; j<_ip; j++) {
                     hi h = _hinfo[i*_ip+j];
                     data_out[i] += data_in[h.index]
                                 * static_cast<meshdata_t>(h.weight);
@@ -252,7 +252,7 @@ void vfps::RotationMap::genHInfo(vfps::meshindex_t x0,
             }
         }
     } else {
-        for (uint_fast8_t i=0; i<_ip; i++) {
+        for (decltype(_ip) i=0; i<_ip; i++) {
             myhinfo[i] = {0,0};
         }
     }


### PR DESCRIPTION
As this is a rather unimportant fix, it is not needed for v1.1 and filed against dev.

Remark: It would be thinkable that the value of _ip exceeds the limit of uint_fast8_t, causing an infinite loop. However, it is known (but not guaranteed by the file type) that _ip <= 4.