### PR TITLE
Simplify cl_code_integral_sum

### DIFF
--- a/src/PS/PhaseSpace.cpp
+++ b/src/PS/PhaseSpace.cpp
@@ -532,14 +532,14 @@ std::string vfps::PhaseSpace::cl_code_integral = R"(
     )";
 std::string vfps::PhaseSpace::cl_code_integral_sum = R"(
     __kernel void integralSum(const __global float* bp,
-                           const uint xsize,
-                           __global float* result)
+                              const uint xsize,
+                              __global float result)
     {
         float value = 0;
         for (uint x=0; x< xsize; x++) {
             value += bp[x];
         }
-        *result = value;
+        result = value;
     }
     )";
 

--- a/src/PS/PhaseSpace.cpp
+++ b/src/PS/PhaseSpace.cpp
@@ -533,7 +533,7 @@ std::string vfps::PhaseSpace::cl_code_integral = R"(
 std::string vfps::PhaseSpace::cl_code_integral_sum = R"(
     __kernel void integralSum(const __global float* bp,
                               const uint xsize,
-                              __global float result)
+                              float result)
     {
         float value = 0;
         for (uint x=0; x< xsize; x++) {


### PR DESCRIPTION
`__kernel void integralSum()` works on an atomic value, not an an array. Thus, it can be simplified.