### PR TITLE
Fix handling of effective voltage for linearRF=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 set (INOVESA_VERSION_MAJOR 1)
 set (INOVESA_VERSION_MINOR 1)
-set (INOVESA_VERSION_FIX 1)
+set (INOVESA_VERSION_FIX 2)
 # pre release numbers:
 # -1: alpha
 # -2: beta

--- a/src/MessageStrings.cpp
+++ b/src/MessageStrings.cpp
@@ -19,6 +19,7 @@ const std::string vfps::copyright_notice() noexcept {
         "Copyright (c) Johannes Schestag\n"
         "Copyright (c) Tobias Boltz\n"
         "Copyright (c) Patrick Schreiber\n"
+        "Copyright (c) Miriam Brosi\n"
         "Copyright (c) Julian Gethmann\n"
         "Copyright (c) Matthias Blaicher\n"
         "Copyright (c) John C. Bowman,\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -525,7 +525,7 @@ int main(int argc, char** argv)
             Display::printText("Building dynamic, nonlinear RFKickMap...");
 
             drfm.reset(new DynamicRFKickMap( grid_t2, grid_t1,ps_size, ps_size
-                                           , revolutionpart, V_eff, f_RF, V0
+                                           , revolutionpart, V_RF, f_RF, V0
                                            , rf_phase_noise, rf_ampl_noise
                                            , rf_mod_ampl,rf_mod_step, laststep
                                            , interpolationtype,interpol_clamp
@@ -560,7 +560,7 @@ int main(int argc, char** argv)
         } else {
             Display::printText("Building static, nonlinear RFKickMap.");
             rfm.reset(new RFKickMap( grid_t2,grid_t1,ps_size,ps_size
-                                   , revolutionpart, V_eff, f_RF, V0
+                                   , revolutionpart, V_RF, f_RF, V0
                                    , interpolationtype,interpol_clamp
                                    , oclh
                                    ));


### PR DESCRIPTION
Fixed problem with the experimental nonlinear RF feature.  When using the nonlinear RF feature (linearRF=0) the effective voltage (V_eff) was mistakenly given to RFKickMAP and DynamicRFKickMap, even though the energy loss is already considered via the synchronous phase.  Tests showed that now the bunch length damps to the calculated natural bunch length with and without linearRF.