### PR TITLE
Adds stdint.h to fix missing uint32_t

### DIFF
--- a/inc/defines.hpp
+++ b/inc/defines.hpp
@@ -10,6 +10,7 @@
 #include <complex>
 #include <string>
 #include <fftw3.h>
+#include <stdint.h>
 
 #include "InovesaConfig.hpp"
 

--- a/inc/defines.hpp
+++ b/inc/defines.hpp
@@ -10,7 +10,7 @@
 #include <complex>
 #include <string>
 #include <fftw3.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include "InovesaConfig.hpp"
 


### PR DESCRIPTION
On newer systems, compilation throws an error of "‘uint32_t’ does not name a type".

This pull request is adding the stdint.h header to fix this issue.